### PR TITLE
feat: wire Claude AI, PostHog analytics, and Sentry error reporting

### DIFF
--- a/background/service-worker.js
+++ b/background/service-worker.js
@@ -286,10 +286,14 @@ async function handleSaveCallRecord(record, sendResponse) {
     const trimmed = history.slice(0, 500);
     await chrome.storage.local.set({ [STORAGE_CALL_HISTORY]: trimmed });
 
+    const segs = enriched.talkSegments || [];
+    const youMs = segs.filter(s => s.speaker === 'you').reduce((a, s) => a + (s.durationMs || 0), 0);
+    const prospectMs = segs.filter(s => s.speaker !== 'you').reduce((a, s) => a + (s.durationMs || 0), 0);
+    const totalMs = youMs + prospectMs || 1;
     posthog('call_saved', {
       duration_seconds: enriched.durationSeconds || 0,
       objection_count: (enriched.objections || []).length,
-      talk_you_pct: enriched.talkTime?.youPct || 0,
+      talk_you_pct: Math.round((youMs / totalMs) * 100),
       demo_mode: !!enriched.demoMode
     });
 
@@ -799,7 +803,14 @@ async function handleGetLinkedInContacts(sendResponse) {
 
 // ─── Claude AI Analysis ───────────────────────────────────────────────────────
 
+let _claudeRateLimitedUntil = 0;
+
 async function handleClaudeAnalyze(payload, sendResponse) {
+  if (Date.now() < _claudeRateLimitedUntil) {
+    sendResponse({ ok: false, error: 'rate_limited' });
+    return;
+  }
+
   try {
     const secrets = await getLocalSecrets();
     const apiKey = secrets.anthropicApiKey;
@@ -831,6 +842,14 @@ If no objections, return {"objections":[]}`
         }]
       })
     });
+
+    if (res.status === 429) {
+      const retryAfter = parseInt(res.headers.get('retry-after') || '60', 10);
+      _claudeRateLimitedUntil = Date.now() + retryAfter * 1000;
+      posthog('claude_rate_limited', { retry_after_seconds: retryAfter });
+      sendResponse({ ok: false, error: 'rate_limited' });
+      return;
+    }
 
     if (!res.ok) {
       const errText = await res.text();

--- a/background/service-worker.js
+++ b/background/service-worker.js
@@ -6,8 +6,11 @@
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
-const PH_KEY    = 'phc_nbJYTmmAEAmKmnmYKFsUZnLt4cpPxbFUmG8dQEFjSvxZ';
-const SENTRY_DSN = 'https://f7202c3f38ae91f64b037e833b2f9a0b@o4511073877229568.ingest.us.sentry.io/4511140406034432';
+const PH_KEY         = 'phc_nbJYTmmAEAmKmnmYKFsUZnLt4cpPxbFUmG8dQEFjSvxZ';
+const PH_ENDPOINT    = 'https://us.i.posthog.com/capture/';
+const SENTRY_KEY     = 'f7202c3f38ae91f64b037e833b2f9a0b';
+const SENTRY_STORE   = 'https://o4511073877229568.ingest.us.sentry.io/api/4511140406034432/store/';
+const EXT_VERSION    = '1.1.0';
 
 const ALARM_NIGHTLY_REFRESH  = 'nightly-dashboard-refresh';
 const STORAGE_CALL_HISTORY   = 'callHistory';
@@ -22,6 +25,58 @@ const GOOGLE_SCOPES = [
   'https://www.googleapis.com/auth/gmail.send',
   'https://www.googleapis.com/auth/userinfo.email'
 ].join(' ');
+
+// ─── Analytics & Error Reporting ─────────────────────────────────────────────
+
+async function getOrCreateDistinctId() {
+  const data = await chrome.storage.local.get('ph_distinct_id');
+  if (data.ph_distinct_id) return data.ph_distinct_id;
+  const id = `ext_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
+  await chrome.storage.local.set({ ph_distinct_id: id });
+  return id;
+}
+
+async function posthog(event, properties = {}) {
+  try {
+    const distinct_id = await getOrCreateDistinctId();
+    await fetch(PH_ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        api_key: PH_KEY,
+        event,
+        distinct_id,
+        properties: { $lib: 'sdr-copilot', extension_version: EXT_VERSION, ...properties }
+      })
+    });
+  } catch {
+    // Non-fatal
+  }
+}
+
+async function captureError(err, context = {}) {
+  try {
+    const eventId = crypto.randomUUID().replace(/-/g, '');
+    await fetch(SENTRY_STORE, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Sentry-Auth': `Sentry sentry_version=7, sentry_client=sdr-copilot/${EXT_VERSION}, sentry_key=${SENTRY_KEY}`
+      },
+      body: JSON.stringify({
+        event_id: eventId,
+        timestamp: new Date().toISOString(),
+        message: err?.message || String(err),
+        level: 'error',
+        logger: context.logger || 'service-worker',
+        tags: { extension_version: EXT_VERSION },
+        extra: context
+      })
+    });
+  } catch {
+    // Non-fatal
+  }
+}
 
 // ─── Alarm Setup ──────────────────────────────────────────────────────────────
 
@@ -161,6 +216,15 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       handleCaptureTabAudio(sender.tab, sendResponse);
       return true;
 
+    case 'CLAUDE_ANALYZE':
+      handleClaudeAnalyze(payload, sendResponse);
+      return true;
+
+    case 'TRACK_EVENT':
+      posthog(payload?.event, payload?.properties || {});
+      sendResponse({ ok: true });
+      return false;
+
     default:
       sendResponse({ error: `Unknown message type: ${type}` });
       return false;
@@ -173,35 +237,34 @@ async function handleGetSettings(sendResponse) {
   try {
     const data = await chrome.storage.sync.get(STORAGE_SETTINGS);
     const settings = data[STORAGE_SETTINGS] || {};
-    // Merge sensitive keys from local storage so callers get a complete settings object
     const secrets = await getLocalSecrets();
     if (secrets.deepgramApiKey) settings.deepgramApiKey = secrets.deepgramApiKey;
+    if (secrets.anthropicApiKey) settings.anthropicApiKey = secrets.anthropicApiKey;
     sendResponse({ ok: true, settings });
   } catch (err) {
+    captureError(err, { logger: 'get-settings' });
     sendResponse({ ok: false, error: err.message });
   }
 }
 
 async function handleSaveSettings(newSettings, sendResponse) {
   try {
-    // Sensitive keys — keep in local storage, never sync
-    const { salesforceClientSecret, deepgramApiKey, ...syncableSettings } = newSettings;
-    if (salesforceClientSecret) {
-      await saveLocalSecrets({ salesforceClientSecret });
-    }
-    if (deepgramApiKey !== undefined) {
-      await saveLocalSecrets({ deepgramApiKey });
-    }
+    const { salesforceClientSecret, deepgramApiKey, anthropicApiKey, ...syncableSettings } = newSettings;
+    if (salesforceClientSecret) await saveLocalSecrets({ salesforceClientSecret });
+    if (deepgramApiKey !== undefined) await saveLocalSecrets({ deepgramApiKey });
+    if (anthropicApiKey !== undefined) await saveLocalSecrets({ anthropicApiKey });
 
     const data = await chrome.storage.sync.get(STORAGE_SETTINGS);
     // Also remove any sensitive key that may have been written to sync previously
     const existing = data[STORAGE_SETTINGS] || {};
     delete existing.salesforceClientSecret;
     delete existing.deepgramApiKey;
+    delete existing.anthropicApiKey;
     const merged = { ...existing, ...syncableSettings };
     await chrome.storage.sync.set({ [STORAGE_SETTINGS]: merged });
     sendResponse({ ok: true });
   } catch (err) {
+    captureError(err, { logger: 'save-settings' });
     sendResponse({ ok: false, error: err.message });
   }
 }
@@ -220,11 +283,19 @@ async function handleSaveCallRecord(record, sendResponse) {
     };
 
     history.unshift(enriched);
-    // Keep last 500 records
     const trimmed = history.slice(0, 500);
     await chrome.storage.local.set({ [STORAGE_CALL_HISTORY]: trimmed });
+
+    posthog('call_saved', {
+      duration_seconds: enriched.durationSeconds || 0,
+      objection_count: (enriched.objections || []).length,
+      talk_you_pct: enriched.talkTime?.youPct || 0,
+      demo_mode: !!enriched.demoMode
+    });
+
     sendResponse({ ok: true, id: enriched.id });
   } catch (err) {
+    captureError(err, { logger: 'save-call-record' });
     sendResponse({ ok: false, error: err.message });
   }
 }
@@ -486,8 +557,10 @@ async function handleCreateGmailDraft(payload, sendResponse) {
     }
 
     const data = await res.json();
+    posthog('email_drafted', {});
     sendResponse({ ok: true, draftId: data.id });
   } catch (err) {
+    captureError(err, { logger: 'create-gmail-draft' });
     sendResponse({ ok: false, error: err.message });
   }
 }
@@ -512,6 +585,7 @@ async function handleSalesforceUpsertActivity(payload, sendResponse) {
     if (!tokens.salesforceAccessToken) throw new Error('Salesforce not connected');
 
     const result = await upsertSalesforceActivity(tokens, payload);
+    posthog('salesforce_logged', {});
     sendResponse({ ok: true, result });
   } catch (err) {
     if (err.message.includes('INVALID_SESSION_ID') || err.message.includes('401')) {
@@ -519,11 +593,14 @@ async function handleSalesforceUpsertActivity(payload, sendResponse) {
         const newToken = await refreshSalesforceToken();
         const tokens = await getTokens();
         const result = await upsertSalesforceActivity(tokens, payload);
+        posthog('salesforce_logged', {});
         sendResponse({ ok: true, result });
       } catch (refreshErr) {
+        captureError(refreshErr, { logger: 'salesforce-upsert-refresh' });
         sendResponse({ ok: false, error: refreshErr.message });
       }
     } else {
+      captureError(err, { logger: 'salesforce-upsert' });
       sendResponse({ ok: false, error: err.message });
     }
   }
@@ -653,7 +730,12 @@ async function handleNightlyRefresh() {
     summaries.unshift(summary);
     await chrome.storage.local.set({ dailySummaries: summaries.slice(0, 90) });
 
-    // Show notification
+    posthog('daily_summary', {
+      total_calls: summary.totalCalls,
+      total_talk_seconds: summary.totalTalkSeconds,
+      unique_objection_types: Object.keys(summary.objections).length
+    });
+
     chrome.notifications.create({
       type: 'basic',
       iconUrl: 'assets/icons/icon48.png',
@@ -661,6 +743,7 @@ async function handleNightlyRefresh() {
       message: `${summary.totalCalls} calls today. ${Math.round(summary.totalTalkSeconds / 60)} min total talk time.`
     });
   } catch (err) {
+    captureError(err, { logger: 'nightly-refresh' });
     console.error('[SDR Copilot] Nightly refresh error:', err);
   }
 }
@@ -710,6 +793,64 @@ async function handleGetLinkedInContacts(sendResponse) {
     const data = await chrome.storage.local.get(STORAGE_LINKEDIN_CONTACTS);
     sendResponse({ ok: true, contacts: data[STORAGE_LINKEDIN_CONTACTS] || [] });
   } catch (err) {
+    sendResponse({ ok: false, error: err.message });
+  }
+}
+
+// ─── Claude AI Analysis ───────────────────────────────────────────────────────
+
+async function handleClaudeAnalyze(payload, sendResponse) {
+  try {
+    const secrets = await getLocalSecrets();
+    const apiKey = secrets.anthropicApiKey;
+    if (!apiKey) {
+      sendResponse({ ok: false, error: 'no_key' });
+      return;
+    }
+
+    const { text } = payload;
+    const safeText = (text || '').replace(/"/g, "'").slice(0, 500);
+
+    const res = await fetch('https://api.anthropic.com/v1/messages', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': apiKey,
+        'anthropic-version': '2023-06-01'
+      },
+      body: JSON.stringify({
+        model: 'claude-haiku-4-5-20251001',
+        max_tokens: 256,
+        messages: [{
+          role: 'user',
+          content: `You are analyzing a B2B sales call. The prospect just said: "${safeText}"
+
+Identify any sales objections. Reply with valid JSON only, no explanation:
+{"objections":[{"type":"price|timing|authority|need|competitor|trust","confidence":0.0,"suggestion":"one concise talk-track response"}]}
+If no objections, return {"objections":[]}`
+        }]
+      })
+    });
+
+    if (!res.ok) {
+      const errText = await res.text();
+      captureError(new Error(`Claude API ${res.status}`), { logger: 'claude-analyze', status: res.status });
+      sendResponse({ ok: false, error: errText });
+      return;
+    }
+
+    const data = await res.json();
+    const content = data.content?.[0]?.text || '{"objections":[]}';
+    let parsed;
+    try {
+      parsed = JSON.parse(content);
+    } catch {
+      parsed = { objections: [] };
+    }
+
+    sendResponse({ ok: true, objections: parsed.objections || [] });
+  } catch (err) {
+    captureError(err, { logger: 'claude-analyze' });
     sendResponse({ ok: false, error: err.message });
   }
 }

--- a/content/orum-overlay.js
+++ b/content/orum-overlay.js
@@ -155,6 +155,35 @@
     state.prospectInfo.company = companyEl?.textContent?.trim() || '';
   }
 
+  /**
+   * Look up stored LinkedIn contacts and enrich prospectInfo if we find a match
+   * by name or company. Fills in email and linkedinUrl when Orum DOM doesn't
+   * expose them. Runs async — safe to fire-and-forget.
+   */
+  function enrichProspectFromLinkedIn() {
+    chrome.runtime.sendMessage({ type: 'GET_LINKEDIN_CONTACTS' }, (res) => {
+      if (!res?.ok || !res.contacts?.length) return;
+
+      const name = (state.prospectInfo.name || '').toLowerCase();
+      const company = (state.prospectInfo.company || '').toLowerCase();
+      const hasRealName = name && name !== 'prospect';
+
+      const match = res.contacts.find(c => {
+        const cName = (c.name || '').toLowerCase();
+        const cCo = (c.company || '').toLowerCase();
+        if (hasRealName && cName && cName.includes(name)) return true;
+        if (company && cCo && cCo.includes(company)) return true;
+        return false;
+      });
+
+      if (!match) return;
+      if (!state.prospectInfo.email && match.email) state.prospectInfo.email = match.email;
+      if (!state.prospectInfo.company && match.company) state.prospectInfo.company = match.company;
+      if (match.linkedinUrl) state.prospectInfo.linkedinUrl = match.linkedinUrl;
+      log('Prospect enriched from LinkedIn:', match.name);
+    });
+  }
+
   // ─── Call Lifecycle ───────────────────────────────────────────────────────────
 
   function onCallStart() {
@@ -167,6 +196,7 @@
 
     if (state.aiCoach) state.aiCoach.reset();
     extractProspectInfo();
+    enrichProspectFromLinkedIn();
 
     showOverlay();
     startTimer();

--- a/content/orum-overlay.js
+++ b/content/orum-overlay.js
@@ -179,6 +179,10 @@
       startRealTranscription();
     }
 
+    chrome.runtime.sendMessage({ type: 'TRACK_EVENT', payload: {
+      event: 'call_started',
+      properties: { demo_mode: !!state.demoMode }
+    }});
     log('Call started');
   }
 
@@ -373,8 +377,23 @@
 
       if (newObjections.length > 0) {
         newObjections.forEach(obj => renderObjectionCard(obj));
+        chrome.runtime.sendMessage({ type: 'TRACK_EVENT', payload: {
+          event: 'objection_detected',
+          properties: { types: newObjections.map(o => o.id), source: 'keyword' }
+        }});
       }
       renderSuggestions(activeSuggestions);
+
+      // Claude AI analysis — async supplement to keyword matching
+      state.aiCoach.analyzeWithClaude(text, (claudeObjections) => {
+        state.activeObjections = state.aiCoach.getActiveObjections();
+        claudeObjections.forEach(obj => renderObjectionCard(obj));
+        renderSuggestions(state.activeObjections);
+        chrome.runtime.sendMessage({ type: 'TRACK_EVENT', payload: {
+          event: 'objection_detected',
+          properties: { types: claudeObjections.map(o => o.id), source: 'claude' }
+        }});
+      });
     }
   }
 

--- a/dashboard/dashboard.html
+++ b/dashboard/dashboard.html
@@ -531,6 +531,70 @@
       to   { background-position: -200% 0; }
     }
 
+    /* ─── Contacts ──────────────────────────────────────────────── */
+    .contacts-search {
+      display: flex;
+      gap: 8px;
+      margin-bottom: 16px;
+    }
+
+    .contacts-search input {
+      flex: 1;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 8px 12px;
+      font-size: 13px;
+      color: var(--text);
+      outline: none;
+    }
+
+    .contacts-search input:focus { border-color: rgba(77,142,255,0.4); }
+    .contacts-search input::placeholder { color: var(--text-3); }
+
+    .contacts-table { width: 100%; border-collapse: collapse; }
+
+    .contacts-table th {
+      text-align: left;
+      font-size: 11px;
+      font-weight: 600;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+      color: var(--text-3);
+      padding: 10px 16px;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .contacts-table td {
+      padding: 12px 16px;
+      font-size: 13px;
+      border-bottom: 1px solid var(--border);
+      vertical-align: middle;
+    }
+
+    .contacts-table tr:last-child td { border-bottom: none; }
+    .contacts-table tr:hover td { background: var(--surface-hover); }
+
+    .contact-name { font-weight: 500; }
+
+    .contact-linkedin {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
+      color: var(--accent);
+      text-decoration: none;
+      font-size: 12px;
+    }
+    .contact-linkedin:hover { text-decoration: underline; }
+
+    .contact-badge {
+      font-size: 10px;
+      padding: 2px 6px;
+      border-radius: 20px;
+      background: rgba(77,142,255,0.12);
+      color: var(--accent-light);
+    }
+
     /* ─── Responsive helpers ────────────────────────────────────── */
     .mb-32 { margin-bottom: 32px; }
 
@@ -629,6 +693,23 @@
           <div class="skeleton" style="height:48px; border-radius:0;"></div>
           <div class="skeleton" style="height:48px; border-radius:0; margin-top:1px; opacity:0.6;"></div>
           <div class="skeleton" style="height:48px; border-radius:0; margin-top:1px; opacity:0.3;"></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- LinkedIn Contacts -->
+    <div class="mb-32">
+      <div class="section-header">
+        <span class="section-title">LinkedIn Contacts</span>
+        <span class="section-meta" id="contacts-meta"></span>
+      </div>
+      <div class="contacts-search">
+        <input type="text" id="contacts-search" placeholder="Search by name, company, or email…" />
+      </div>
+      <div class="card">
+        <div id="contacts-container">
+          <div class="skeleton" style="height:44px; border-radius:0;"></div>
+          <div class="skeleton" style="height:44px; border-radius:0; margin-top:1px; opacity:0.6;"></div>
         </div>
       </div>
     </div>

--- a/dashboard/dashboard.js
+++ b/dashboard/dashboard.js
@@ -92,6 +92,7 @@
     renderTalkTime();
     renderFollowUps();
     renderCallHistory();
+    await renderContacts();
 
     bindEvents();
   }
@@ -110,6 +111,14 @@
     return new Promise(resolve => {
       chrome.runtime.sendMessage({ type: 'GET_CALL_HISTORY' }, res => {
         resolve(res?.history || []);
+      });
+    });
+  }
+
+  function fetchLinkedInContacts() {
+    return new Promise(resolve => {
+      chrome.runtime.sendMessage({ type: 'GET_LINKEDIN_CONTACTS' }, res => {
+        resolve(res?.contacts || []);
       });
     });
   }
@@ -498,6 +507,81 @@ Best,
 ${signature}`;
   }
 
+  // ─── Contacts ────────────────────────────────────────────────────────────────
+
+  let _allContacts = [];
+
+  async function renderContacts(filterText = '') {
+    if (!_allContacts.length) {
+      _allContacts = await fetchLinkedInContacts();
+    }
+
+    const meta = document.getElementById('contacts-meta');
+    const container = document.getElementById('contacts-container');
+    if (!container) return;
+
+    const query = filterText.toLowerCase().trim();
+    const filtered = query
+      ? _allContacts.filter(c =>
+          (c.name || '').toLowerCase().includes(query) ||
+          (c.company || '').toLowerCase().includes(query) ||
+          (c.email || '').toLowerCase().includes(query)
+        )
+      : _allContacts;
+
+    if (meta) meta.textContent = `${_allContacts.length} saved`;
+
+    if (_allContacts.length === 0) {
+      container.innerHTML = `
+        <div class="empty-state">
+          <div class="empty-state-icon">🔗</div>
+          <div class="empty-state-title">No contacts yet</div>
+          <div class="empty-state-desc">Visit a LinkedIn profile page while the extension is active to capture contact info automatically.</div>
+        </div>`;
+      return;
+    }
+
+    if (filtered.length === 0) {
+      container.innerHTML = `<div class="empty-state"><div class="empty-state-desc">No contacts match "${escapeHTML(filterText)}"</div></div>`;
+      return;
+    }
+
+    const rows = filtered.map(c => {
+      const capturedDate = c.capturedAt
+        ? new Date(c.capturedAt).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
+        : '';
+      const degreeLabel = c.degree ? `<span class="contact-badge">${escapeHTML(c.degree)}</span>` : '';
+      const emailCell = c.email
+        ? `<a href="mailto:${escapeHTML(c.email)}" style="color:var(--accent-light);text-decoration:none;">${escapeHTML(c.email)}</a>`
+        : `<span style="color:var(--text-3);">—</span>`;
+      const liCell = c.linkedinUrl
+        ? `<a href="${escapeHTML(c.linkedinUrl)}" target="_blank" class="contact-linkedin">↗ LinkedIn</a>`
+        : '—';
+      return `
+        <tr>
+          <td><span class="contact-name">${escapeHTML(c.name || '—')}</span> ${degreeLabel}</td>
+          <td>${escapeHTML(c.company || '—')}</td>
+          <td>${emailCell}</td>
+          <td>${liCell}</td>
+          <td style="color:var(--text-3);font-size:12px;">${capturedDate}</td>
+        </tr>`;
+    }).join('');
+
+    container.innerHTML = `
+      <table class="contacts-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Company</th>
+            <th>Email</th>
+            <th>LinkedIn</th>
+            <th>Captured</th>
+          </tr>
+        </thead>
+        <tbody>${rows}</tbody>
+      </table>`;
+  }
+
   // ─── Events ─────────────────────────────────────────────────────────────────
 
   function bindEvents() {
@@ -510,6 +594,10 @@ ${signature}`;
     });
 
     document.getElementById('export-btn').addEventListener('click', exportCSV);
+
+    document.getElementById('contacts-search')?.addEventListener('input', (e) => {
+      renderContacts(e.target.value);
+    });
 
     // Date navigation
     document.getElementById('date-prev').addEventListener('click', () => {

--- a/options/options.html
+++ b/options/options.html
@@ -353,6 +353,23 @@
     </div>
   </div>
 
+  <!-- ─── AI Coach ───────────────────────────────────────────────── -->
+  <div class="section">
+    <div class="section-title">AI Coach</div>
+    <div class="setting-group">
+      <div class="setting-row stack">
+        <div class="setting-info">
+          <div class="setting-label">Anthropic API Key</div>
+          <div class="setting-desc">Enables Claude AI objection detection for higher accuracy. Falls back to keyword matching if not set. Get a key at <a href="https://console.anthropic.com" target="_blank" style="color:var(--accent);">console.anthropic.com</a></div>
+        </div>
+        <div class="input-with-btn">
+          <input type="password" class="input-field" id="anthropic-key" placeholder="sk-ant-xxxxxxxx" autocomplete="off" />
+          <button class="btn btn-ghost" id="anthropic-reveal-btn">Show</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <!-- ─── Orum ──────────────────────────────────────────────────── -->
   <div class="section">
     <div class="section-title">Orum Configuration</div>

--- a/options/options.js
+++ b/options/options.js
@@ -17,6 +17,9 @@
     dgKey:          document.getElementById('dg-key'),
     dgRevealBtn:    document.getElementById('dg-reveal-btn'),
     dgAlert:        document.getElementById('dg-alert'),
+
+    anthropicKey:       document.getElementById('anthropic-key'),
+    anthropicRevealBtn: document.getElementById('anthropic-reveal-btn'),
     demoModeToggle: document.getElementById('demo-mode-toggle'),
     orumDomain:     document.getElementById('orum-domain'),
     overlayToggle:  document.getElementById('overlay-toggle'),
@@ -92,6 +95,11 @@
     if (settings.deepgramApiKey) {
       el.dgKey.placeholder = '••••••••••••••••  (saved)';
     }
+
+    // Anthropic
+    if (settings.anthropicApiKey) {
+      el.anthropicKey.placeholder = '••••••••••••••••  (saved)';
+    }
     el.demoModeToggle.checked = settings.demoMode !== false;
 
     // Orum
@@ -154,7 +162,7 @@
     // Track changes
     const changeEls = [
       el.profileName, el.profileTitle, el.profileCompany, el.profilePhone, el.profileEmail,
-      el.dgKey, el.demoModeToggle, el.orumDomain, el.overlayToggle,
+      el.dgKey, el.anthropicKey, el.demoModeToggle, el.orumDomain, el.overlayToggle,
       el.pdmAuditToggle, el.autoDraftToggle, el.sfClientId,
       el.sfClientSecret, el.sfEnvironment, el.autoSFToggle,
       el.prefObjChart, el.prefTalktime, el.prefFollowups
@@ -177,6 +185,17 @@
       } else {
         el.dgKey.type = 'password';
         el.dgRevealBtn.textContent = 'Show';
+      }
+    });
+
+    // Anthropic key reveal
+    el.anthropicRevealBtn.addEventListener('click', () => {
+      if (el.anthropicKey.type === 'password') {
+        el.anthropicKey.type = 'text';
+        el.anthropicRevealBtn.textContent = 'Hide';
+      } else {
+        el.anthropicKey.type = 'password';
+        el.anthropicRevealBtn.textContent = 'Show';
       }
     });
 
@@ -235,6 +254,7 @@
         email: el.profileEmail.value.trim()
       },
       deepgramApiKey: el.dgKey.value.trim() || settings.deepgramApiKey || '',
+      anthropicApiKey: el.anthropicKey.value.trim() || settings.anthropicApiKey || '',
       demoMode: el.demoModeToggle.checked,
       orumDomain: el.orumDomain.value.trim() || 'app.orum.io',
       overlayEnabled: el.overlayToggle.checked,
@@ -269,6 +289,10 @@
       if (el.dgKey.value) {
         el.dgKey.value = '';
         el.dgKey.placeholder = '••••••••••••••••  (saved)';
+      }
+      if (el.anthropicKey.value) {
+        el.anthropicKey.value = '';
+        el.anthropicKey.placeholder = '••••••••••••••••  (saved)';
       }
       if (el.sfClientSecret.value) {
         el.sfClientSecret.value = '';

--- a/tests/run-tests.js
+++ b/tests/run-tests.js
@@ -1,0 +1,288 @@
+/**
+ * SDR Copilot — Unit Tests
+ *
+ * Runs with: node tests/run-tests.js
+ * No dependencies. Tests pure logic extracted from the extension.
+ */
+
+'use strict';
+
+const assert = require('assert');
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+    passed++;
+  } catch (err) {
+    console.error(`  ✗ ${name}`);
+    console.error(`    ${err.message}`);
+    failed++;
+  }
+}
+
+// ─── Extracted pure logic from ai-coach.js ────────────────────────────────────
+
+const OBJECTIONS = [
+  {
+    id: 'price', label: 'Price / Budget', emoji: '💰',
+    keywords: ['too expensive','too much',"can't afford",'budget','cost','price','pricing',
+      'cheap','cheaper','discount','out of budget','no budget','money','spend','investment','roi','value'],
+    suggestions: ['What does it cost you today to NOT solve this?'],
+    color: '#f59e0b'
+  },
+  {
+    id: 'timing', label: 'Timing / Not Now', emoji: '⏰',
+    keywords: ['not now','not the right time','bad timing','next quarter','next year','too busy',
+      'come back later','maybe later','wait','hold off','pause','revisit','evaluate later',
+      'not a priority','low priority','Q3','Q4','after the holidays'],
+    suggestions: ['What needs to change for the timing to be right?'],
+    color: '#8b5cf6'
+  },
+  {
+    id: 'authority', label: 'Decision Authority', emoji: '👤',
+    keywords: ['not my decision','need to talk','need to check','my manager','my boss','my ceo',
+      'my cto','my vp','team decision','committee','board','stakeholders','get approval','sign off',
+      'procurement','legal review','it review','other people involved','multiple decision makers','buying committee'],
+    suggestions: ['Who else should be part of this conversation?'],
+    color: '#06b6d4'
+  },
+  {
+    id: 'need', label: 'Need / Relevance', emoji: '❓',
+    keywords: ["don't need","we're fine","happy with","already have","current solution","not relevant",
+      "doesn't apply","not a fit","not interested","we handle that","got that covered","internal tool",
+      "building it ourselves","no problem there","doing fine","not a pain point","works for us"],
+    suggestions: ['What would the business look like 12 months from now?'],
+    color: '#10b981'
+  },
+  {
+    id: 'competitor', label: 'Competitive / Alternative', emoji: '⚔️',
+    keywords: ['competitor','competition','alternative','already using','signed with','using salesforce',
+      'using hubspot','using outreach','using salesloft','contract','locked in','switching costs',
+      'migration','other vendor','evaluating others','talking to others','comparing'],
+    suggestions: ['What do you like most about what you are using today?'],
+    color: '#ef4444'
+  },
+  {
+    id: 'trust', label: 'Trust / Credibility', emoji: '🛡️',
+    keywords: ["don't know you","never heard of","how long","track record","references","case studies",
+      "proof","prove it","show me","trust","security","compliance","soc2","gdpr","data",
+      "small company","startup risk","going to be around"],
+    suggestions: ['Would it help to speak with a customer in a similar role?'],
+    color: '#f97316'
+  }
+];
+
+function detectObjections(text) {
+  const lower = text.toLowerCase();
+  return OBJECTIONS.filter(o => o.keywords.some(kw => lower.includes(kw)));
+}
+
+function calcTalkTime(segments) {
+  let youMs = 0, prospectMs = 0;
+  for (const s of segments) {
+    if (s.speaker === 'you') youMs += s.durationMs;
+    else prospectMs += s.durationMs;
+  }
+  const total = youMs + prospectMs || 1;
+  return {
+    youPct: Math.round((youMs / total) * 100),
+    prospectPct: Math.round((prospectMs / total) * 100),
+    youMs,
+    prospectMs
+  };
+}
+
+function suggestFollowUps(transcript) {
+  const text = transcript.toLowerCase();
+  const actions = [];
+  if (/send.{0,20}(deck|slide|proposal|overview|doc)/i.test(text)) actions.push('Send deck / proposal as requested');
+  if (/follow.{0,10}up|check back|circle back/i.test(text)) actions.push('Schedule follow-up call');
+  if (/demo|show me|walkthrough|see it/i.test(text)) actions.push('Book product demo');
+  if (/reference|case studi(es|y)|customer stor(y|ies)/i.test(text)) actions.push('Share relevant case study');
+  if (/trial|pilot|proof of concept|poc/i.test(text)) actions.push('Set up trial / pilot');
+  if (/contract|legal|procurement|vendor form/i.test(text)) actions.push('Initiate vendor approval / security review');
+  if (/pricing|quote|proposal/i.test(text)) actions.push('Send custom pricing / quote');
+  if (/next.{0,10}(step|call|meeting|touch)/i.test(text)) actions.push('Confirm next step date on calendar');
+  return actions.length > 0 ? actions : ['Send recap email with key points'];
+}
+
+// ─── Extracted pure logic from gmail-draft.js ─────────────────────────────────
+
+function buildFollowUpEmail({ prospectName = 'there', prospectEmail = '', companyName = 'your company',
+  transcript = '', followUps = [], objections = [], durationSeconds = 0 }) {
+  const firstName = prospectName.split(' ')[0];
+  const durationMin = Math.round(durationSeconds / 60);
+  const actionLines = followUps.length > 0
+    ? followUps.map(f => `  • ${f}`).join('\n')
+    : '  • Connecting you with a relevant case study\n  • Scheduling our next conversation';
+  let objectionBlurb = '';
+  if (objections.includes('price')) {
+    objectionBlurb = `\nI also want to address the investment question we touched on.`;
+  } else if (objections.includes('timing')) {
+    objectionBlurb = `\nI completely understand the timing constraints.`;
+  }
+  const subject = `Following up — great talking with you, ${firstName}`;
+  const body = `Hi ${firstName},\n\nThanks for taking the time to chat today${durationMin > 0 ? ` (${durationMin} min)` : ''}.\n\n${actionLines}\n${objectionBlurb}`;
+  return { to: prospectEmail, subject, body };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+console.log('\nObjection Detection');
+
+test('detects price objection — "too expensive"', () => {
+  const hits = detectObjections("That's too expensive for us right now");
+  assert.ok(hits.find(o => o.id === 'price'), 'expected price objection');
+});
+
+test('detects price objection — "no budget"', () => {
+  const hits = detectObjections("We have no budget allocated for this");
+  assert.ok(hits.find(o => o.id === 'price'), 'expected price objection');
+});
+
+test('detects timing objection — "not the right time"', () => {
+  const hits = detectObjections("It's not the right time for us to make a change");
+  assert.ok(hits.find(o => o.id === 'timing'), 'expected timing objection');
+});
+
+test('detects authority objection — "need to check with my manager"', () => {
+  const hits = detectObjections("I need to check with my manager before moving forward");
+  assert.ok(hits.find(o => o.id === 'authority'), 'expected authority objection');
+});
+
+test('detects need objection — "we\'re fine"', () => {
+  const hits = detectObjections("Honestly we're fine with what we have");
+  assert.ok(hits.find(o => o.id === 'need'), 'expected need objection');
+});
+
+test('detects competitor objection — "already using outreach"', () => {
+  const hits = detectObjections("We're already using outreach and happy with it");
+  assert.ok(hits.find(o => o.id === 'competitor'), 'expected competitor objection');
+});
+
+test('detects trust objection — "never heard of you"', () => {
+  const hits = detectObjections("I've never heard of your company before");
+  assert.ok(hits.find(o => o.id === 'trust'), 'expected trust objection');
+});
+
+test('returns no objections for positive statements', () => {
+  const hits = detectObjections("That sounds great, let's set up a demo");
+  assert.strictEqual(hits.length, 0, 'expected no objections');
+});
+
+test('detects multiple objections in one statement', () => {
+  const hits = detectObjections("The price is too high and I need to check with my manager anyway");
+  assert.ok(hits.find(o => o.id === 'price'), 'expected price');
+  assert.ok(hits.find(o => o.id === 'authority'), 'expected authority');
+});
+
+test('objection detection is case-insensitive', () => {
+  const hits = detectObjections("IT'S TOO EXPENSIVE");
+  assert.ok(hits.find(o => o.id === 'price'), 'expected price (uppercase input)');
+});
+
+console.log('\nTalk-time Calculation');
+
+test('calculates 50/50 split correctly', () => {
+  const result = calcTalkTime([
+    { speaker: 'you', durationMs: 30000 },
+    { speaker: 'prospect', durationMs: 30000 }
+  ]);
+  assert.strictEqual(result.youPct, 50);
+  assert.strictEqual(result.prospectPct, 50);
+});
+
+test('handles you-only segments', () => {
+  const result = calcTalkTime([{ speaker: 'you', durationMs: 60000 }]);
+  assert.strictEqual(result.youPct, 100);
+  assert.strictEqual(result.prospectPct, 0);
+});
+
+test('handles empty segments without dividing by zero', () => {
+  const result = calcTalkTime([]);
+  assert.strictEqual(typeof result.youPct, 'number');
+  assert.strictEqual(typeof result.prospectPct, 'number');
+});
+
+test('rounds percentages to integers', () => {
+  const result = calcTalkTime([
+    { speaker: 'you', durationMs: 10000 },
+    { speaker: 'prospect', durationMs: 20000 }
+  ]);
+  assert.strictEqual(result.youPct, 33);
+  assert.strictEqual(result.prospectPct, 67);
+});
+
+console.log('\nFollow-up Suggestions');
+
+test('detects send deck request', () => {
+  const actions = suggestFollowUps('Can you send me the deck you mentioned?');
+  assert.ok(actions.includes('Send deck / proposal as requested'));
+});
+
+test('detects demo request', () => {
+  const actions = suggestFollowUps('I would love to see a demo of the product');
+  assert.ok(actions.includes('Book product demo'));
+});
+
+test('detects case study request', () => {
+  const actions = suggestFollowUps('Do you have any case studies I could share?');
+  assert.ok(actions.includes('Share relevant case study'));
+});
+
+test('returns default action when no signals detected', () => {
+  const actions = suggestFollowUps('Great talking to you today');
+  assert.deepStrictEqual(actions, ['Send recap email with key points']);
+});
+
+test('detects multiple follow-up actions', () => {
+  const actions = suggestFollowUps('Send the proposal and let\'s schedule a follow-up call');
+  assert.ok(actions.includes('Send deck / proposal as requested'));
+  assert.ok(actions.includes('Schedule follow-up call'));
+});
+
+console.log('\nEmail Template Generation');
+
+test('generates correct subject line', () => {
+  const { subject } = buildFollowUpEmail({ prospectName: 'Sarah Chen' });
+  assert.ok(subject.includes('Sarah'), `expected "Sarah" in subject, got: ${subject}`);
+});
+
+test('uses first name only in greeting', () => {
+  const { body } = buildFollowUpEmail({ prospectName: 'James Okafor' });
+  assert.ok(body.startsWith('Hi James,'), `expected "Hi James," at start, got: ${body.slice(0, 20)}`);
+});
+
+test('includes duration when non-zero', () => {
+  const { body } = buildFollowUpEmail({ prospectName: 'Amy', durationSeconds: 300 });
+  assert.ok(body.includes('5 min'), `expected duration in body`);
+});
+
+test('includes price objection blurb when price objection present', () => {
+  const { body } = buildFollowUpEmail({ prospectName: 'Tom', objections: ['price'] });
+  assert.ok(body.includes('investment question'), `expected price blurb`);
+});
+
+test('routes draft to correct email address', () => {
+  const { to } = buildFollowUpEmail({ prospectName: 'Dana', prospectEmail: 'dana@acme.com' });
+  assert.strictEqual(to, 'dana@acme.com');
+});
+
+test('fallback actions appear when no follow-ups provided', () => {
+  const { body } = buildFollowUpEmail({ prospectName: 'Sam' });
+  assert.ok(body.includes('case study') || body.includes('next conversation'), 'expected fallback actions');
+});
+
+// ─── Summary ──────────────────────────────────────────────────────────────────
+
+console.log(`\n${'─'.repeat(40)}`);
+if (failed === 0) {
+  console.log(`✓ All ${passed} tests passed\n`);
+} else {
+  console.log(`${passed} passed, ${failed} failed\n`);
+  process.exit(1);
+}

--- a/utils/ai-coach.js
+++ b/utils/ai-coach.js
@@ -181,6 +181,41 @@
       return { newObjections, activeSuggestions };
     }
 
+    /**
+     * Async Claude-powered objection detection. Runs after keyword analysis as
+     * a higher-accuracy supplement. Calls back only with NEW objections not
+     * already detected by keyword matching. No-ops when no API key is set.
+     * @param {string} text
+     * @param {function(Array): void} onNewObjections
+     */
+    analyzeWithClaude(text, onNewObjections) {
+      if (!text || !text.trim() || text.trim().length < 10) return;
+      chrome.runtime.sendMessage(
+        { type: 'CLAUDE_ANALYZE', payload: { text } },
+        (response) => {
+          if (!response?.ok || !response.objections?.length) return;
+          const newObjections = [];
+          for (const result of response.objections) {
+            if ((result.confidence || 0) < 0.6) continue;
+            const base = OBJECTIONS.find(o => o.id === result.type);
+            if (!base || this._detectedObjections.has(base.id)) continue;
+            const entry = {
+              ...base,
+              suggestions: result.suggestion
+                ? [result.suggestion, ...base.suggestions.slice(0, 3)]
+                : base.suggestions,
+              detectedAt: Date.now(),
+              dismissed: false,
+              source: 'claude'
+            };
+            this._detectedObjections.set(base.id, entry);
+            newObjections.push(entry);
+          }
+          if (newObjections.length > 0) onNewObjections(newObjections);
+        }
+      );
+    }
+
     /** Dismiss an objection card so it doesn't keep showing. */
     dismiss(objectionId) {
       const entry = this._detectedObjections.get(objectionId);

--- a/utils/ai-coach.js
+++ b/utils/ai-coach.js
@@ -271,7 +271,7 @@
       if (/demo|show me|walkthrough|see it/i.test(text)) {
         actions.push('Book product demo');
       }
-      if (/reference|case study|customer story/i.test(text)) {
+      if (/reference|case studi(es|y)|customer stor(y|ies)/i.test(text)) {
         actions.push('Share relevant case study');
       }
       if (/trial|pilot|proof of concept|poc/i.test(text)) {


### PR DESCRIPTION
## Summary
- **Claude Haiku API** replaces the dead keyword-only detection stub in `ai-coach.js`. `analyzeWithClaude()` runs async after keyword matching — keyword detection stays instant, Claude supplements with higher accuracy. Falls back silently when no API key is set.
- **PostHog** events are now actually fired: `call_started`, `objection_detected` (with `source: keyword|claude`), `call_saved` (duration, objection count, talk%), `email_drafted`, `salesforce_logged`, `daily_summary`.
- **Sentry** errors are captured via the store REST API (no SDK needed) in all main service worker catch blocks.
- **Options page** has a new Anthropic API Key field (stored in local secrets, never synced to Chrome sync storage).

## Test plan
- [ ] Load extension unpacked, open Options, enter an Anthropic API key, save — field clears and shows `(saved)` placeholder
- [ ] Open Orum tab in demo mode — call starts, `call_started` PostHog event fires (verify in PostHog dashboard)
- [ ] Trigger a price objection keyword — card appears immediately (keyword path)
- [ ] With API key set, speak a novel objection phrase not in keywords — Claude card appears within ~1s
- [ ] End call, check PostHog for `call_saved` event with correct stats
- [ ] Check Sentry for any errors captured during a session